### PR TITLE
redisを外部化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 postgres-data
+/terraform/.terraform

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ x-redash-service: &redash-service
   image: redash/redash:9.0.0-beta.b42121
   depends_on:
     - postgres
-    - redis
   env_file: ./env
   restart: always
 services:
@@ -32,9 +31,6 @@ services:
     environment:
       QUEUES: "queries"
       WORKERS_COUNT: 2
-  redis:
-    image: redis:5.0-alpine
-    restart: always
   postgres:
     image: postgres:9.6-alpine
     env_file: ./env

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  region = "ap-northeast-1"
+}
+
+resource "aws_elasticache_cluster" "redash" {
+  cluster_id           = "redash"
+  engine               = "redis"
+  engine_version       = "5.0.6"
+  port                 = 6379
+  parameter_group_name = "default.redis5.0"
+  node_type            = "cache.t2.micro"
+  num_cache_nodes      = 1
+}


### PR DESCRIPTION
手順
Redisインスタンスのセキュリティグループのインバウンドに
port 6379、ソースにRedashサーバーのセキュリティグループを追加

https://ariarijp.hatenablog.com/entry/2018/06/19/212310